### PR TITLE
Ensure `this.props.styles` handles false/undefined

### DIFF
--- a/src/notification.js
+++ b/src/notification.js
@@ -11,7 +11,7 @@ var Notification = React.createClass({
      * If styles is set to false,
      * then return nothing.
      */
-    if (!this.props.styles) {
+    if (this.props.styles === false) {
       return styles;
     }
 
@@ -36,7 +36,7 @@ var Notification = React.createClass({
 
     styles = !this.state.active ? styles.default : objectAssign(styles.default, styles.active);
 
-    if (this.props.styles.bar) {
+    if (this.props.styles && this.props.styles.bar) {
       styles = objectAssign(styles, this.props.styles.bar);
     }
 
@@ -52,7 +52,7 @@ var Notification = React.createClass({
      * If styles is set to false,
      * then return nothing.
      */
-    if (!this.props.styles) {
+    if (this.props.styles === false) {
       return styles;
     }
 
@@ -68,7 +68,7 @@ var Notification = React.createClass({
       font: '.75rem normal Roboto, sans-serif',
     };
 
-    if (this.props.styles.action) {
+    if (this.props.styles && this.props.styles.action) {
       styles = objectAssign(styles, this.props.styles.action);
     }
 


### PR DESCRIPTION
Hey Patrick,

This is kinda a lazy pull instead of an issue ticket - I wasn't getting styles applied to the snackbar when leaving off the `styles` prop:

```html
<Notification message="Hello world" />
```

This obviously leaves the `this.props.style` as `undefined` which looks like the `getActionStyles` code bails out for BOTH conditions (`false` and leaving it off, ie. `undefined`):

```js
// Line 56ish
     /**
     * If styles is set to false,
     * then return nothing.
     */
    if (!this.props.styles) {
      return styles;
    }
```

I was having to set `styles={true}` to make it work "normally", which seems not so right. Switching the above to explicitly check for `false` got me across the line.

This cascaded a bit further down in the same `getActionStyles` as it was causing errors where `this.props.style` was undefined (or 'true', or anything not an _object_) here:

```js
// Line 75ish
if (this.props.styles.action) {
  // ...
}
```

So made that do a sanity check on `this.props.styles` first, and voila no more errors.

I have a sneaking suspicion that my issues might be local, but I figured I'd PR this in as half-question half-assist ;) I'd have written some additional tests here, but `jest` is failing on my end on a straight git-clone npm install and wow it's easter weekend and y'know chocolate!

Thanks for the work on this man, handy component!
(happy to clean up this PR if you've got any feedback)
