### PR TITLE
Add a timeout prop to dismiss the notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ See [here](/bin/tests/test.js).
 | message   | string          | The message for the notification                    | true      |
 | action    | string          | The name of the action, e.g., "close" or "undo"     |           |
 | styles    | object || bool  | Styles to apply to the component*                   |           |
+| dismissAfter | integer      | Time in milliseconds to dismiss the notification (eg. `2000` for 2 seconds) |           |
 
 *Setting this prop to `false` will disable all inline styles. This is useful if you aren't using React inline styles and would like to use CSS instead. See [styles](#styles) for more.
 

--- a/src/notification.js
+++ b/src/notification.js
@@ -123,6 +123,15 @@ var Notification = React.createClass({
     };
   },
 
+  componentWillReceiveProps: function (nextProps) {
+    if (!nextProps.dismissAfter) return;
+
+    if (this.state.timeoutId) clearTimeout( this.state.timeoutId );
+    this.state.timeoutId = setTimeout( this.hide(), nextProps.dismissAfter );
+
+    this.setState(this.state);
+  },
+
   render: function () {
     return (
       <div className="notification-bar" style={this.getBarStyles()}>


### PR DESCRIPTION
Hey Patrick - another fairly useful addition I've found in using the notification component. Adds a `dismissAfter` optional property that hides the notification after the number of milliseconds specified has passed.

Let me know if you want any tweaks before you merge (location of `componentWillReceiveProps` or naming of `dismissAfter` in particular).