### PR TITLE
#24 Trigger browser to use GPU acceleration

### DIFF
--- a/src/notification.js
+++ b/src/notification.js
@@ -50,7 +50,17 @@ export default class Notification extends Component {
         borderSizing: 'border-box',
         boxShadow: '0 0 1px 1px rgba(10, 10, 11, .125)',
         cursor: 'default',
-        transition: '.5s cubic-bezier(0.89, 0.01, 0.5, 1.1)'
+        WebKittransition: '.5s cubic-bezier(0.89, 0.01, 0.5, 1.1)',
+        MozTransition: '.5s cubic-bezier(0.89, 0.01, 0.5, 1.1)',
+        msTransition: '.5s cubic-bezier(0.89, 0.01, 0.5, 1.1)',
+        oTransition: '.5s cubic-bezier(0.89, 0.01, 0.5, 1.1)',
+        transition: '.5s cubic-bezier(0.89, 0.01, 0.5, 1.1)',
+        // Trigger GPU acceleration
+        WebkitTransform: 'translatez(0)',
+        MozTransform: 'translatez(0)',
+        msTransform: 'translatez(0)',
+        oTransform: 'translatez(0)',
+        transform: 'translatez(0)'
       },
       activeState: {
         left: '1rem'


### PR DESCRIPTION
Using the translationZ(0) triggers GPU acceleration in modern desktop and mobile browsers. 
http://blog.teamtreehouse.com/increase-your-sites-performance-with-hardware-accelerated-css