### PR TITLE
Fix propType validation for action

### DIFF
--- a/src/notification.js
+++ b/src/notification.js
@@ -4,7 +4,10 @@ import objectAssign from 'object-assign';
 export default class Notification extends Component {
   static propTypes = {
     message: PropTypes.string.isRequired,
-    action: PropTypes.string.isRequired,
+    action: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.bool
+    ]),
     onClick: PropTypes.func,
     styles: PropTypes.oneOfType([
       PropTypes.object,
@@ -15,6 +18,7 @@ export default class Notification extends Component {
   }
 
   static defaultProps = {
+    action: false,
     isActive: false,
     dismissAfter: 2000
   }


### PR DESCRIPTION
According to #25 the `action` prop is not required, and you should be able to pass `false`.

However, when passing `false` the React `propType` validation fails:

```
Warning: Failed propType: Invalid prop `action` of type `boolean` supplied to `Notification`, expected `string`.
```

This fixes the problem, and also makes `action` default to `false`.

@pburtchaell 