### PR TITLE
Use dismissAfter from the current notification, instead of that of the previous one.

### DIFF
--- a/src/notification.js
+++ b/src/notification.js
@@ -21,7 +21,7 @@ export default class Notification extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.onDismiss && nextProps.isActive) {
-      setTimeout(nextProps.onDismiss, this.props.dismissAfter);
+      setTimeout(nextProps.onDismiss, nextProps.dismissAfter);
     }
   }
 


### PR DESCRIPTION
The previous value of dismissAfter was used instead of the new one when setting the onDismiss timeout, causing notifications to dismiss with the previous notifications dismiss-time, instead of the one you sent in.