### PR TITLE
Added className & activeClassName props

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Install the component via npm: `npm install react-notification`.
 | message   | string             | The message for the notification                  | true      |          |
 | action    | string             | The name of the action, e.g., "close" or "undo"   | true      |          |
 | style     | object or boolean  | Custom styles to apply to the component*          |           |          |
+| className | string             | Custom class to apply to the top-level component  |           |          |
 | dismissAfter | number          | Timeout for onDismiss event                       |           | `2000`   |
 
 *Setting this prop to `false` will disable all inline styles. This is useful if you aren't using React inline styles and would like to use CSS instead. See [styles](#styles) for more.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Install the component via npm: `npm install react-notification`.
 | action    | string             | The name of the action, e.g., "close" or "undo"   | true      |          |
 | style     | object or boolean  | Custom styles to apply to the component*          |           |          |
 | className | string             | Custom class to apply to the top-level component  |           |          |
+| activeClassName | string             | Custom class to apply to the top-level component when active |           |          |
 | dismissAfter | number          | Timeout for onDismiss event                       |           | `2000`   |
 
 *Setting this prop to `false` will disable all inline styles. This is useful if you aren't using React inline styles and would like to use CSS instead. See [styles](#styles) for more.

--- a/src/notification.js
+++ b/src/notification.js
@@ -12,12 +12,14 @@ export default class Notification extends Component {
     ]),
     dismissAfter: PropTypes.number,
     onDismis: PropTypes.func,
-    className: PropTypes.string
+    className: PropTypes.string,
+    activeClassName: PropTypes.string
   }
 
   static defaultProps = {
     isActive: false,
-    dismissAfter: 2000
+    dismissAfter: 2000,
+    activeClassName: 'notification-bar-active'
   }
 
   componentWillReceiveProps(nextProps) {
@@ -143,7 +145,10 @@ export default class Notification extends Component {
   }
 
   render() {
-    const className = 'notification-bar ' + (this.props.className || '');
+    let className = 'notification-bar';
+    if (this.props.isActive) className += ' ' + this.props.activeClassName;
+    if (this.props.className) className += ' ' + this.props.className;
+
     return (
       <div className={className} style={this.getBarStyle()}>
         <div className="notification-bar-wrapper" onClick={this.handleClick}>

--- a/src/notification.js
+++ b/src/notification.js
@@ -11,7 +11,8 @@ export default class Notification extends Component {
       PropTypes.bool
     ]),
     dismissAfter: PropTypes.number,
-    onDismis: PropTypes.func
+    onDismis: PropTypes.func,
+    className: PropTypes.string
   }
 
   static defaultProps = {
@@ -142,8 +143,9 @@ export default class Notification extends Component {
   }
 
   render() {
+    const className = 'notification-bar ' + (this.props.className || '');
     return (
-      <div className="notification-bar" style={this.getBarStyle()}>
+      <div className={className} style={this.getBarStyle()}>
         <div className="notification-bar-wrapper" onClick={this.handleClick}>
           <span className="notification-bar-message">{this.props.message}</span>
           {this.props.action !== false ? (


### PR DESCRIPTION
I just added a `className` prop to be able to add classes to the top-level div of the component.
And an `activeClassName` prop to be applied when the notification is active (i.e supposed to be showing) with the default value of 'notification-bar-active'

This is pretty useful for those that don't use inline styles.