### PR TITLE
do not set more timeouts when recieving props and clear the timeout w…

### DIFF
--- a/src/notification.js
+++ b/src/notification.js
@@ -32,6 +32,10 @@ export default class Notification extends Component {
     }
   }
 
+  componentWillUnmount() {
+    clearTimeout(this.dismissTimeout);
+  }
+
   /*
    * @description Dynamically get the styles for the bar.
    * @returns {object} result The style.

--- a/src/notification.js
+++ b/src/notification.js
@@ -27,8 +27,8 @@ export default class Notification extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.onDismiss && nextProps.isActive) {
-      setTimeout(nextProps.onDismiss, nextProps.dismissAfter);
+    if (nextProps.onDismiss && nextProps.isActive && !this.props.isActive) {
+      this.dismissTimeout = setTimeout(nextProps.onDismiss, nextProps.dismissAfter);
     }
   }
 


### PR DESCRIPTION
…hen a notification component is unmounted

I have a need to stack any number of these notifications on the page at once. I have a component containing an array of notification objects in state. The render function of this component maps over the array, rendering Notification components. The onDismiss handler for each Notification updates state with a new array omitting the dismissed notification .

I pass a style prop into each Notification to update the placement according to where the notification exists in the list.

This passing of new props has the side effect of creating a new timeout to call onDismiss, thus my pull request. Essentially I'm seeing a setState getting called on a component that is no longer mounted, producing a warning from React. The proposed change prevents that from happening.