### PR TITLE
Updated message type to accept React element

### DIFF
--- a/src/defaultPropTypes.js
+++ b/src/defaultPropTypes.js
@@ -1,7 +1,10 @@
 import { PropTypes } from 'react';
 
 export default {
-  message: PropTypes.string.isRequired,
+  message: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element
+  ]).isRequired,
   action: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.string


### PR DESCRIPTION
This allows us to pass a react element to the notification as a message, without throwing a warning.

This is useful if, for example, we want to add an icon before the notification message.