### PR TITLE
Solve Timeout behaviour

### DIFF
--- a/examples/single-notification/index.js
+++ b/examples/single-notification/index.js
@@ -32,6 +32,7 @@ class Example extends Component {
           action="Dismiss"
           title="Title!"
           onDismiss={this.toggleNotification.bind(this)}
+          onClick={() =>  this.setState({ isActive: false })}
         />
       </div>
     );

--- a/src/notification.js
+++ b/src/notification.js
@@ -12,7 +12,8 @@ class Notification extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.onDismiss && nextProps.isActive && !this.props.isActive) {
+    if (nextProps.onDismiss && this.props.onDismiss === nextProps.onDismiss && nextProps.isActive && !this.props.isActive) {
+      clearTimeout(this.dismissTimeout);
       this.dismissTimeout = setTimeout(nextProps.onDismiss, nextProps.dismissAfter);
     }
   }

--- a/src/stackedNotification.js
+++ b/src/stackedNotification.js
@@ -1,11 +1,6 @@
 import React, { Component } from 'react';
 import Notification from './notification';
 
-/**
- * The notification list does not have any state, so use a
- * pure function here. It just needs to return the stacked array
- * of notification components.
- */
 class StackedNotification extends Component {
   constructor(props) {
     super(props);


### PR DESCRIPTION
## Timeout behaviour
Since the Notification Component fires the timer when receive props and verify the (if) condition, it is necessary a `clearTimeout` to avoid not desired behaviour with different timers fired.
Add an extra condition to only apply if has same `onDismiss` so don't brake the Notification Stack behaviour.

See the images below for a visual example:

#### wrong
![notif_wrong](https://cloud.githubusercontent.com/assets/784056/14276616/d53c736e-fb1f-11e5-95b4-5904876c589d.gif)

#### right
![notif_ok](https://cloud.githubusercontent.com/assets/784056/14276682/0f033664-fb20-11e5-944c-4203c58ef476.gif)


## Example `onClick` function
Add the missed function to show its behaviour

## Commet
Remove a duplicated comment that described a _functional Component_ in a extended `Class` Component.