### PR TITLE
Allow `action` and `onClick` for Stacked Notifications

### DIFF
--- a/examples/notification-tree/index.js
+++ b/examples/notification-tree/index.js
@@ -8,30 +8,44 @@ class Example extends Component {
     super(props);
 
     this.state = {
-      notifications: OrderedSet(),
-
-      // This is just used for the sake of an example to make sure
-      // notifications have unique keys. In production, you should have
-      // a different system for UIDs.
-      count: 0
+      notifications: {},
     };
+
+    this.removeNotification = this.removeNotification.bind(this);
+    this.renderNotifications = this.renderNotifications.bind(this);
   }
 
+
   addNotification() {
-    const { notifications, count } = this.state;
-    const id = notifications.size + 1;
-    const newCount = count + 1;
+    // This is just used for the sake of an example to make sure
+    // notifications have unique keys. In production, you should have
+    // a different system for UIDs.
+    const id = Date.now();
+
+    const notifications = Object.assign({}, this.state.notifications, {
+      [id]: {
+        action: 'Dismiss',
+        dismissAfter: 3400,
+        onClick: () => this.removeNotification(id),
+        message: `Notification ${id}`,
+        key: id
+      }
+    });
 
     return this.setState({
-      count: newCount,
-      notifications: notifications.add({
-        message: `Notification ${id}`,
-        key: newCount,
-        barStyle: {
-          background: 'grey'
-        }
-      })
+      notifications: notifications
     });
+  }
+
+  removeNotification (notif) {
+    const notifications = Object.assign({}, this.state.notifications);
+    delete notifications[notif];
+
+    this.setState({ notifications })
+  }
+  
+  renderNotifications () {
+    return Object.keys(this.state.notifications).map(notif => this.state.notifications[notif])
   }
 
   render() {
@@ -41,10 +55,8 @@ class Example extends Component {
           Add notification
         </button>
         <NotificationStack
-          notifications={this.state.notifications.toArray()}
-          onDismiss={notification => this.setState({
-            notifications: this.state.notifications.delete(notification)
-          })}
+          notifications={this.renderNotifications()}
+          onDismiss={notif => this.removeNotification(notif.key)}
         />
       </div>
     );

--- a/src/notificationStack.js
+++ b/src/notificationStack.js
@@ -21,7 +21,6 @@ const NotificationStack = props => {
             isLast={isLast}
             action={notification.action || props.action}
             dismissAfter={isLast ? dismissAfter : dismissAfter + (index * 1000)}
-            onClick={() => props.onDismiss(notification)}
             onDismiss={() => {
               setTimeout(() => {
                 setTimeout(props.onDismiss.bind(this, notification), 300);

--- a/src/stackedNotification.js
+++ b/src/stackedNotification.js
@@ -11,13 +11,17 @@ class StackedNotification extends Component {
   }
 
   componentDidMount() {
-    setTimeout(this.setState.bind(this, {
+    this.activeTimeout = setTimeout(this.setState.bind(this, {
       isActive: true
     }), 1);
 
-    setTimeout(this.setState.bind(this, {
+    this.dismissTimeout = setTimeout(this.setState.bind(this, {
       isActive: false
     }), this.props.dismissAfter);
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.dismissTimeout);
   }
 
   render() {
@@ -26,7 +30,6 @@ class StackedNotification extends Component {
     return (
       <Notification
         {...this.props}
-        action={false}
         isActive={this.state.isActive}
         barStyle={Object.assign({}, {
           bottom: bottomPosition


### PR DESCRIPTION
Add references to timeouts that allows to clear them before unmount each notification. 
So, let available to add `action` and `onClick` props in `Notification`s Components inside a Stack. #46 

I tryied to let the example as it is (using `OrderedSet`from Immutable.js) but didn't find a way to reference each generated `Notification` Component inside its own `onClick` prop, so I changed the example with a raw Object, referenced with an _unique_ id  based on `Date.now()` (with the same advice comment).

![stacnotif](https://cloud.githubusercontent.com/assets/784056/14331697/b1481986-fc46-11e5-89bb-0d0f7840de2c.gif)

This resolves #46.