### PR TITLE
Add the ability to set permanent notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ For Notification component:
 | actionStyle     | object                  | Custom action styles                                        |           |                            |
 | className       | string                  | Custom class to apply to the top-level component            |           |                            |
 | activeClassName | string                  | Custom class to apply to the top-level component when active|           | `'notification-bar-active'`|
-| dismissAfter    | number                  | Timeout for onDismiss event                                 |           | `2000`                     |
+| dismissAfter    | number or false         | Timeout for onDismiss event                                 |           | `2000`                     |
 
 The `style` prop useful if you are not using React inline styles and would like to use CSS instead. See [styles](#styles) for more.
 

--- a/src/defaultPropTypes.js
+++ b/src/defaultPropTypes.js
@@ -14,7 +14,10 @@ export default {
   actionStyle: PropTypes.object,
   barStyle: PropTypes.object,
   activeBarStyle: PropTypes.object,
-  dismissAfter: PropTypes.number,
+  dismissAfter: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number
+  ]),
   onDismiss: PropTypes.func,
   className: PropTypes.string,
   activeClassName: PropTypes.string.isRequired,

--- a/src/notification.js
+++ b/src/notification.js
@@ -12,6 +12,7 @@ class Notification extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    if (this.props.dismissAfter === false) return;
     if (!nextProps.hasOwnProperty('isLast'))
       clearTimeout(this.dismissTimeout);
     if (nextProps.onDismiss && nextProps.isActive && !this.props.isActive) {
@@ -20,7 +21,7 @@ class Notification extends Component {
   }
 
   componentWillUnmount() {
-    clearTimeout(this.dismissTimeout);
+    if (this.props.dismissAfter) clearTimeout(this.dismissTimeout);
   }
 
   /*

--- a/src/stackedNotification.js
+++ b/src/stackedNotification.js
@@ -15,9 +15,11 @@ class StackedNotification extends Component {
       isActive: true
     }), 1);
 
-    this.dismissTimeout = setTimeout(this.setState.bind(this, {
-      isActive: false
-    }), this.props.dismissAfter);
+    if (this.props.dismissAfter) {
+      this.dismissTimeout = setTimeout(this.setState.bind(this, {
+        isActive: false
+      }), this.props.dismissAfter);
+    }
   }
 
   componentWillUnmount() {

--- a/test/notification.js
+++ b/test/notification.js
@@ -160,4 +160,34 @@ describe('<Notification />', () => {
       }
     }, mockNotification.dismissAfter);
   });
+  it('onDismiss fires once when dismissAfter is passed', () => {
+    const handleDismiss = spy();
+
+    const wrapper = shallow(
+      <Notification
+        message={mockNotification.message}
+        dismissAfter={mockNotification.dismissAdter}
+        onDismiss={handleDismiss}
+      />
+    );
+
+    setTimeout(() => {
+      expect(handleDismiss.calledOnce).to.equal(true);
+    }, mockNotification.dismissAfter);
+  });
+
+  it('onDismiss does not get fired when dismissAfter is false', () => {
+    const handleDismiss = spy();
+
+    const wrapper = shallow(
+      <Notification
+        message={mockNotification.message}
+        dismissAfter={false}
+        onDismiss={handleDismiss}
+      />
+    );
+
+    expect(handleDismiss.calledOnce).to.equal(false);
+  });
+
 });


### PR DESCRIPTION
I am running into a use case where I want my notifications to only be dismissible by user action, not automatically after a timeout. This PR ads that ability, by passing `false` as the `dismissAfter` prop to `<Notification>`s.

I didn't want to change the default behavior of `dismissAfter`, as it could break for existing users.