### PR TITLE
Patch for #66 and Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "express-urlrewrite": "^1.2.0",
     "html-webpack-plugin": "^2.10.0",
     "immutable": "^3.8.1",
+    "jsdom": "^8.5.0",
     "mocha": "^2.4.5",
     "react": "^0.14.7",
     "react-addons-test-utils": "^0.14.7",

--- a/src/notification.js
+++ b/src/notification.js
@@ -12,8 +12,9 @@ class Notification extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.onDismiss && this.props.onDismiss === nextProps.onDismiss && nextProps.isActive && !this.props.isActive) {
+    if (!nextProps.hasOwnProperty('isLast'))
       clearTimeout(this.dismissTimeout);
+    if (nextProps.onDismiss && nextProps.isActive && !this.props.isActive) {
       this.dismissTimeout = setTimeout(nextProps.onDismiss, nextProps.dismissAfter);
     }
   }

--- a/src/notificationStack.js
+++ b/src/notificationStack.js
@@ -21,11 +21,7 @@ const NotificationStack = props => {
             isLast={isLast}
             action={notification.action || props.action}
             dismissAfter={isLast ? dismissAfter : dismissAfter + (index * 1000)}
-            onDismiss={() => {
-              setTimeout(() => {
-                setTimeout(props.onDismiss.bind(this, notification), 300);
-              }, 300);
-            }}
+            onDismiss={props.onDismiss.bind(this, notification)}
             index={index}
           />
         );

--- a/src/stackedNotification.js
+++ b/src/stackedNotification.js
@@ -22,6 +22,7 @@ class StackedNotification extends Component {
 
   componentWillUnmount() {
     clearTimeout(this.dismissTimeout);
+    clearTimeout(this.dismissTimeout);
   }
 
   render() {
@@ -30,6 +31,7 @@ class StackedNotification extends Component {
     return (
       <Notification
         {...this.props}
+        onDismiss={() => setTimeout(this.props.onDismiss, 300)}
         isActive={this.state.isActive}
         barStyle={Object.assign({}, {
           bottom: bottomPosition

--- a/test/notification.js
+++ b/test/notification.js
@@ -115,4 +115,49 @@ describe('<Notification />', () => {
 
     expect(handleClick.calledOnce).to.equal(true);
   });
+
+  it('onDismiss does not fire before `dismissAfter` value times out', done => {
+    const handleDismiss = spy();
+
+    const wrapper = mount(
+      <Notification
+        message={mockNotification.message}
+        dismissAfter={mockNotification.dismissAfter}
+        onDismiss={handleDismiss}
+      />
+    );
+    
+    expect(handleDismiss.calledOnce).to.equal(false);
+    wrapper.setProps({ isActive: true });
+    setTimeout(() => {
+      try {
+        expect(handleDismiss.calledOnce).to.equal(false);
+        done();
+      } catch (e) {
+        done(e);
+      }
+    }, mockNotification.dismissAfter / 2);
+  });
+
+  it('onDismiss fires after `dismissAfter` value times out', done => {
+    const handleDismiss = spy();
+
+    const wrapper = mount(
+      <Notification
+        message={mockNotification.message}
+        dismissAfter={mockNotification.dismissAfter}
+        onDismiss={handleDismiss}
+      />
+    );
+    
+    wrapper.setProps({ isActive: true });
+    setTimeout(() => {
+      try {
+        expect(handleDismiss.calledOnce).to.equal(true);
+        done();
+      } catch (e) {
+        done(e);
+      }
+    }, mockNotification.dismissAfter);
+  });
 });

--- a/test/notificationStack.js
+++ b/test/notificationStack.js
@@ -2,19 +2,57 @@ import { Notification, NotificationStack } from '../src/index';
 import mockNotification from './mockNotification';
 
 describe('<NotificationStack />', () => {
-  it('onDismiss fires once', () => {
+  let notifications;
+
+  beforeEach(() => {
+    notifications = [
+      mockNotification,
+      Object.assign({}, mockNotification, { key: 2222 })
+    ];
+  });
+
+  it('onDismiss fires after `dismissAfter` value + transition time', done => {
     const handleDismiss = spy();
 
-    const wrapper = shallow(
+    const wrapper = mount(
       <NotificationStack
-        notifications={[mockNotification]}
+        notifications={notifications}
         onDismiss={handleDismiss}
       />
     );
-
+    
+    wrapper.update();
     setTimeout(() => {
-      expect(handleDismiss.calledOnce).to.equal(true);
-    }, mockNotification.dismissAfter);
+      try {
+        expect(handleDismiss.calledOnce).to.equal(true);
+        done();
+      } catch (e) {
+        done(e);
+      }
+      // Add time due to each StackedNotification transition time ( > 300 )
+    }, mockNotification.dismissAfter + 340);
+  });
+
+  it('onDismiss fires on each Notification in the stack', done => {
+    const handleDismiss = spy();
+
+    const wrapper = mount(
+      <NotificationStack
+        notifications={notifications}
+        onDismiss={handleDismiss}
+      />
+    );
+    
+    wrapper.update();
+    setTimeout(() => {
+      try {
+        expect(handleDismiss.callCount).to.equal(notifications.length);
+        done();
+      } catch (e) {
+        done(e);
+      }
+      // Add transition time + 1000ms per each Notification 
+    }, mockNotification.dismissAfter + 1340);
   });
 
   it('onDismiss does not fire until `dismissAfter` value times out', () => {

--- a/test/setup.js
+++ b/test/setup.js
@@ -9,5 +9,22 @@ global.React = require('react');
 global.expect = require('chai').expect;
 global.spy = require('sinon').spy;
 global.shallow = require('enzyme').shallow;
+global.mount = require('enzyme').mount;
+global.jsdom = require('jsdom').jsdom;
+
+var exposedProperties = ['window', 'navigator', 'document'];
+
+global.document = jsdom('');
+global.window = document.defaultView;
+Object.keys(document.defaultView).forEach((property) => {
+  if (typeof global[property] === 'undefined') {
+    exposedProperties.push(property);
+    global[property] = document.defaultView[property];
+  }
+});
+
+global.navigator = {
+  userAgent: 'node.js'
+};
 
 chai.use(chaiEnzyme());


### PR DESCRIPTION
Creating a test for the patch (#66) noted that the tests that have async functions (`setTimeout`) passed silently. Try, for example [here](https://github.com/pburtchaell/react-notification/blob/master/test/notificationStack.js#L16) change between `true` or `false` will pass the Test anyway. So added `jsdom` and use `done()` to make the assertion wait.

Also clean some `clearTimeouts`.