### PR TITLE
Changed proptypes for action in order to remove the proptypes warning when passing a node

### DIFF
--- a/src/defaultPropTypes.js
+++ b/src/defaultPropTypes.js
@@ -5,10 +5,7 @@ export default {
     PropTypes.string,
     PropTypes.element
   ]).isRequired,
-  action: PropTypes.oneOfType([
-    PropTypes.bool,
-    PropTypes.string
-  ]),
+  action: PropTypes.node,
   onClick: PropTypes.func,
   style: PropTypes.bool,
   actionStyle: PropTypes.object,


### PR DESCRIPTION
Found the need to pass an icon in the action prop as mentioned in #36 but I kept receiving a warning because the proptypes were requiring it to either be a String or a Boolean.

Allows `action` to be an element, ie: `<i className="icon"/>`