### PR TITLE
Allow onDismiss to be called without prop update

### DIFF
--- a/src/notification.js
+++ b/src/notification.js
@@ -9,6 +9,13 @@ class Notification extends Component {
     this.getActionStyle = this.getActionStyle.bind(this);
     this.getTitleStyle = this.getTitleStyle.bind(this);
     this.handleClick = this.handleClick.bind(this);
+
+    if (this.props.onDismiss && this.props.isActive) {
+      this.dismissTimeout = setTimeout(
+        this.props.onDismiss,
+        this.props.dismissAfter
+      );
+    }
   }
 
   componentWillReceiveProps(nextProps) {

--- a/test/notification.js
+++ b/test/notification.js
@@ -160,4 +160,26 @@ describe('<Notification />', () => {
       }
     }, mockNotification.dismissAfter);
   });
+
+  it('onDismiss fires correctly without prop change', done => {
+    const handleDismiss = spy();
+
+    const wrapper = mount(
+      <Notification
+        message={mockNotification.message}
+        dismissAfter={mockNotification.dismissAfter}
+        onDismiss={handleDismiss}
+        isActive
+      />
+    );
+
+    setTimeout(() => {
+      try {
+        expect(handleDismiss.calledOnce).to.equal(true);
+        done();
+      } catch (e) {
+        done(e);
+      }
+    }, mockNotification.dismissAfter);
+  })
 });


### PR DESCRIPTION
Addressing issue #70, where onDismiss gets called only when isActive is initially false then set to true. Allows onDismiss to work when notification is initialized with isActive equal to true.