### PR TITLE
Fix only apply dismissTimeout if required

### DIFF
--- a/src/notification.js
+++ b/src/notification.js
@@ -10,7 +10,7 @@ class Notification extends Component {
     this.getTitleStyle = this.getTitleStyle.bind(this);
     this.handleClick = this.handleClick.bind(this);
 
-    if (props.onDismiss && props.isActive) {
+    if (props.onDismiss && props.isActive && props.dismissAfter !== false) {
       this.dismissTimeout = setTimeout(
         props.onDismiss,
         props.dismissAfter


### PR DESCRIPTION
The docs say that if `dismissAfter` is `false`, the timeout won't be applied. This fixes things to actually do that :)