### PR TITLE
fix permanent notifications for NotificationStack

### DIFF
--- a/src/notificationStack.js
+++ b/src/notificationStack.js
@@ -19,7 +19,7 @@ const NotificationStack = props => {
   return (
     <div className="notification-list">
       {props.notifications.map((notification, index) => {
-        const dismissAfter = notification.dismissAfter || props.dismissAfter;
+        const dismissAfter = typeof notification.dismissAfter !== 'undefined' ? notification.dismissAfter : props.dismissAfter;
         const isLast = index === 0 && props.notifications.length === 1;
         const barStyle = props.barStyleFactory(index, notification.barStyle);
         const activeBarStyle = props.activeBarStyleFactory(

--- a/src/notificationStack.js
+++ b/src/notificationStack.js
@@ -33,7 +33,7 @@ const NotificationStack = props => {
             key={notification.key}
             isLast={isLast}
             action={notification.action || props.action}
-            dismissAfter={isLast ? dismissAfter : dismissAfter + (index * 1000)}
+            dismissAfter={isLast || dismissAfter === false ? dismissAfter : dismissAfter + (index * 1000)}
             onDismiss={props.onDismiss.bind(this, notification)}
             activeBarStyle={activeBarStyle}
             barStyle={barStyle}


### PR DESCRIPTION
When 'notification.dismissAfter' was set to 'false', then the value of 'dismissAfter' was set to 'prop.dismissAfter'.