### PR TITLE
Allow notification dismiss timer to start immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,12 @@ The `style` prop useful if you are not using React inline styles and would like 
 
 For NotificationStack component:
 
-| Name                  | Type  | Description                                  | Required  | Default  |
-|-----------------------|-------|----------------------------------------------|---------- |----------|
-| notifications         | array | Array of notifications to render             | true      |          |
-| barStyleFactory       | func  | create the style of the notification         | false     | fn       |
-| activeBarStyleFactory | func  | create the style of the active notification  | false     | fn       |
+| Name                  | Type  | Description                                              | Required  | Default  |
+|-----------------------|-------|----------------------------------------------------------|---------- |----------|
+| notifications         | array | Array of notifications to render                         | true      |          |
+| dismissInOrder        | bool  | If false, notification dismiss timers start immediately  | false     | true     |
+| barStyleFactory       | func  | create the style of the notification                     | false     | fn       |
+| activeBarStyleFactory | func  | create the style of the active notification              | false     | fn       |
 
 **Update** `v5.0.3`: Now notifications used in a stack _can_ have all properties included in the regular notification component.
 

--- a/src/notificationStack.js
+++ b/src/notificationStack.js
@@ -20,6 +20,7 @@ const NotificationStack = props => (
     {props.notifications.map((notification, index) => {
       const dismissAfter = notification.dismissAfter || props.dismissAfter;
       const isLast = index === 0 && props.notifications.length === 1;
+      const dismissNow = isLast || !props.dismissInOrder;
       const barStyle = props.barStyleFactory(index, notification.barStyle);
       const activeBarStyle = props.activeBarStyleFactory(index, notification.activeBarStyle);
 
@@ -29,7 +30,7 @@ const NotificationStack = props => (
           key={notification.key}
           isLast={isLast}
           action={notification.action || props.action}
-          dismissAfter={isLast ? dismissAfter : dismissAfter + (index * 1000)}
+          dismissAfter={dismissNow ? dismissAfter : dismissAfter + (index * 1000)}
           onDismiss={props.onDismiss.bind(this, notification)}
           activeBarStyle={activeBarStyle}
           barStyle={barStyle}
@@ -40,6 +41,7 @@ const NotificationStack = props => (
 );
 
 NotificationStack.propTypes = {
+  dismissInOrder: PropTypes.bool,
   activeBarStyleFactory: PropTypes.func,
   barStyleFactory: PropTypes.func,
   notifications: PropTypes.array.isRequired,
@@ -47,6 +49,7 @@ NotificationStack.propTypes = {
 };
 
 NotificationStack.defaultProps = {
+  dismissInOrder: true,
   dismissAfter: 1000,
   activeBarStyleFactory: defaultStyleFactory,
   barStyleFactory: defaultStyleFactory

--- a/test/notificationStack.js
+++ b/test/notificationStack.js
@@ -33,6 +33,30 @@ describe('<NotificationStack />', () => {
     expect(notification.prop('isActive')).to.equal(false);
   });
 
+  it('notifications dismissed independently if `dismissInOrder` set to false', done => {
+    const handleDismiss = spy();
+
+    const wrapper = mount(
+      <NotificationStack
+        dismissInOrder={false}
+        notifications={notifications}
+        onDismiss={handleDismiss}
+      />
+    );
+
+    wrapper.update();
+
+    setTimeout(() => {
+      try {
+        expect(handleDismiss.calledTwice).to.equal(true);
+        done();
+      } catch (e) {
+        done(e);
+      }
+      // Add time due to each StackedNotification transition time ( > 300 )
+    }, mockNotification.dismissAfter + 340);
+  });
+
   it('onDismiss fires after `dismissAfter` value + transition time', done => {
     const handleDismiss = spy();
 


### PR DESCRIPTION
for notifications in notificationStack. This is as opposed to the normal behavior of waiting 1s for each active notification added earlier.