### PR TITLE
Allow dynamically set dismissAfter over props.

### DIFF
--- a/src/notification.js
+++ b/src/notification.js
@@ -19,18 +19,23 @@ class Notification extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.dismissAfter === false) return;
+    if (nextProps.dismissAfter === false) return;
 
     // See http://eslint.org/docs/rules/no-prototype-builtins
     if (!{}.hasOwnProperty.call(nextProps, 'isLast')) {
       clearTimeout(this.dismissTimeout);
     }
 
-    if (nextProps.onDismiss && nextProps.isActive && !this.props.isActive) {
-      this.dismissTimeout = setTimeout(
-        nextProps.onDismiss,
-        nextProps.dismissAfter
-      );
+    if (nextProps.onDismiss) {
+      if (
+        (nextProps.isActive && !this.props.isActive) ||
+        (nextProps.dismissAfter && this.props.dismissAfter === false)
+      ) {
+        this.dismissTimeout = setTimeout(
+          nextProps.onDismiss,
+          nextProps.dismissAfter
+        );
+      }
     }
   }
 

--- a/src/stackedNotification.js
+++ b/src/stackedNotification.js
@@ -18,16 +18,25 @@ class StackedNotification extends Component {
       isActive: true
     }), 1);
 
-    if (this.props.dismissAfter) {
-      this.dismissTimeout = setTimeout(this.setState.bind(this, {
-        isActive: false
-      }), this.props.dismissAfter);
+    this.dismiss(this.props.dismissAfter);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.dismissAfter !== this.props.dismissAfter) {
+      this.dismiss(nextProps.dismissAfter);
     }
   }
 
   componentWillUnmount() {
     clearTimeout(this.activeTimeout);
     clearTimeout(this.dismissTimeout);
+  }
+
+  dismiss(dismissAfter) {
+    if (dismissAfter === false) return;
+    this.dismissTimeout = setTimeout(this.setState.bind(this, {
+      isActive: false
+    }), dismissAfter);
   }
 
   /*

--- a/test/notificationStack.js
+++ b/test/notificationStack.js
@@ -103,6 +103,43 @@ describe('<NotificationStack />', () => {
     }, mockNotification.dismissAfter + 340);
   });
 
+  it('should dismiss when `dismissAfter` is updated to a number after it was `false`', (done) => {
+    const handleDismiss = spy();
+
+    let dismissAfter = 0;
+
+    const wrapper = mount(
+      <NotificationStack
+        dismissInOrder={false}
+        notifications={[{ ...mockNotification, dismissAfter: false }]}
+        onDismiss={handleDismiss}
+      />
+    );
+    wrapper.update();
+
+    const isDismissed = (called, callback) => {
+      setTimeout(() => {
+        try {
+          expect(handleDismiss.called).to.equal(called);
+          callback();
+        } catch (err) {
+          callback(err);
+        }
+        // Add time due to each StackedNotification transition time ( > 300 )
+      }, dismissAfter + 440);
+    };
+
+    isDismissed(false, (err) => {
+      if (err) return done(err);
+      dismissAfter = 110;
+      wrapper.setProps({
+        notifications: [{ ...mockNotification, dismissAfter }]
+      }, () => {
+        isDismissed(true, done);
+      });
+    });
+  });
+
   it('onDismiss fires on each Notification in the stack', (done) => {
     const handleDismiss = spy();
 


### PR DESCRIPTION
Once we set dismissAfter to false, there is no way to auto dismiss. Now it is possible to set dismissAfter to some value again and onDismiss callback will be called.