### PR TITLE
Remove `npm bin` for Windows suport

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -4,7 +4,7 @@
 # Param 1: the reporter to use, defaults to spec
 runTests()
 {
-  `npm bin`/mocha \
+  node_modules/.bin/mocha \
   --compilers js:babel-core/register \
   --reporter ${1-spec} \
   --recursive --timeout 5000 \
@@ -15,7 +15,7 @@ runTests()
 runIstanbul()
 {
   NODE_ENV=test `npm bin`/istanbul cover \
-  `npm bin`/_mocha \
+  node_modules/.bin/_mocha \
   -- -u exports --compilers js:babel-core/register \
   --report lcovonly \
   test/polyfills.js test/*.js

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "prepublish": "npm run build",
     "precommit": "echo 'Running pre-commit hooks...' && npm test",
     "prebuild": "npm test",
-    "build": "`npm bin`/babel src -d dist",
+    "build": "node_modules/.bin/babel src -d dist",
     "pretest": "npm run lint",
     "test": "./bin/test.sh",
-    "lint": "`npm bin`/eslint src/**/*.js test/**/*.js",
+    "lint": "node_modules/.bin/eslint src/**/*.js test/**/*.js",
     "start": "node examples/server.js"
   },
   "pre-commit": [


### PR DESCRIPTION
This adds support for Windows by removing the ``npm bin`` shorthand and uses the full path to `node_modules/.bin`.