### PR TITLE
Add actionStyleFactory prop to NotificationStack component

### DIFF
--- a/docs/guides/props.md
+++ b/docs/guides/props.md
@@ -27,3 +27,4 @@ The `style` prop useful if you are not using React inline styles and would like 
 | dismissInOrder        | bool  | If false, notification dismiss timers start immediately  | false     | true     |
 | barStyleFactory       | func  | create the style of the notification                     | false     | fn       |
 | activeBarStyleFactory | func  | create the style of the active notification              | false     | fn       |
+| actionStyleFactory    | func  | create the style of the actions                          | false     | fn       |

--- a/src/notificationStack.js
+++ b/src/notificationStack.js
@@ -3,11 +3,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import StackedNotification from './stackedNotification';
 
-function defaultStyleFactory(index, style) {
+function defaultBarStyleFactory(index, style) {
   return Object.assign(
     {},
     style,
     { bottom: `${2 + (index * 4)}rem` }
+  );
+}
+
+function defaultActionStyleFactory(index, style) {
+  return Object.assign(
+    {},
+    style,
+    {}
   );
 }
 
@@ -24,6 +32,7 @@ const NotificationStack = props => (
 
       // Handle styles
       const barStyle = props.barStyleFactory(index, notification.barStyle, notification);
+      const actionStyle = props.actionStyleFactory(index, notification.actionStyle, notification);
       const activeBarStyle = props.activeBarStyleFactory(
         index,
         notification.activeBarStyle,
@@ -52,6 +61,7 @@ const NotificationStack = props => (
           onClick={onClick.bind(this, notification)}
           activeBarStyle={activeBarStyle}
           barStyle={barStyle}
+          actionStyle={actionStyle}
         />
       );
     })}
@@ -62,6 +72,7 @@ const NotificationStack = props => (
 NotificationStack.propTypes = {
   activeBarStyleFactory: PropTypes.func,
   barStyleFactory: PropTypes.func,
+  actionStyleFactory: PropTypes.func,
   dismissInOrder: PropTypes.bool,
   notifications: PropTypes.array.isRequired,
   onDismiss: PropTypes.func.isRequired,
@@ -70,8 +81,9 @@ NotificationStack.propTypes = {
 };
 
 NotificationStack.defaultProps = {
-  activeBarStyleFactory: defaultStyleFactory,
-  barStyleFactory: defaultStyleFactory,
+  activeBarStyleFactory: defaultBarStyleFactory,
+  barStyleFactory: defaultBarStyleFactory,
+  actionStyleFactory: defaultActionStyleFactory,
   dismissInOrder: true,
   dismissAfter: 1000,
   onClick: () => {}

--- a/test/mockNotification.js
+++ b/test/mockNotification.js
@@ -9,7 +9,8 @@ export default {
     background: 'rgb(2, 2, 2)'
   },
   actionStyle: {
-    color: 'rgb(2, 2, 2)'
+    color: 'rgb(2, 2, 2)',
+    letterSpacing: '.125ex'
   },
   activeBarStyle: {
     left: '4rem'

--- a/test/notificationStack.js
+++ b/test/notificationStack.js
@@ -179,7 +179,7 @@ describe('<NotificationStack />', () => {
     expect(notification.prop('barStyle').background).to.equal('rgb(2, 2, 2)');
   });
 
-  it('batStyleFactory should have access to notification', () => {
+  it('barStyleFactory should have access to notification', () => {
     const styleFactory = (index, style, notification) => Object.assign(
       {},
       style,
@@ -257,6 +257,66 @@ describe('<NotificationStack />', () => {
     const notification = stack.find(Notification);
 
     expect(notification.prop('activeBarStyle').color).to.equal('green');
+  });
+
+  it('actionStyleFactory should set correct style on notification', () => {
+    const styleFactory = (index, style) => Object.assign(
+      {},
+      style,
+      { color: 'blue' }
+    );
+
+    const stack = mount(
+      <NotificationStack
+        notifications={[mockNotification]}
+        actionStyleFactory={styleFactory}
+        onDismiss={() => {}}
+      />
+    );
+
+    const notification = stack.find(Notification);
+
+    expect(notification.prop('actionStyle').color).to.equal('blue');
+  });
+
+  it('actionStyleFactory should respect notification actionBarStyle', () => {
+    const styleFactory = (index, style) => Object.assign(
+      {},
+      style,
+      { color: 'blue' }
+    );
+
+    const stack = mount(
+      <NotificationStack
+        notifications={[mockNotification]}
+        actionStyleFactory={styleFactory}
+        onDismiss={() => {}}
+      />
+    );
+
+    const notification = stack.find(Notification);
+
+    expect(notification.prop('actionStyle').letterSpacing).to.equal('.125ex');
+  });
+
+  it('actionStyleFactory should have access to notification', () => {
+    const styleFactory = (index, style, notification) => Object.assign(
+      {},
+      style,
+      { color: notification.key === 1111111 ? 'green' : 'red' }
+    );
+
+    const stack = mount(
+      <NotificationStack
+        notifications={[mockNotification]}
+        actionStyleFactory={styleFactory}
+        onDismiss={() => {}}
+      />
+    );
+
+    const notification = stack.find(Notification);
+
+    expect(notification.prop('actionStyle').color).to.equal('green');
   });
 
   /**


### PR DESCRIPTION
Hey @pburtchaell, long time no see!

Found this library when looking up react notification libs out there and thought it was really cool.  Created this PR because I'm looking to do different stylings depending on the 'level' of the notification (`success`, `error`, etc).

AFAICT the `NotificationStack` component allows us to override the main bar styles, but it didn't seem to give us access to override the styles for the action part.  So this PR attempts to add that in.  

Just let me know if you have some other future direction for this kind of stuff or if there is anything I can fix up.  thanks!