### PR TITLE
Allow test script to run on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,11 @@
     "prebuild": "npm test",
     "build": "node_modules/.bin/babel src -d dist",
     "pretest": "npm run lint",
-    "test": "./bin/test.sh",
+    "test": "cross-env ./bin/test.sh",
     "lint": "node_modules/.bin/eslint src/**/*.js test/**/*.js",
     "start": "node examples/server.js"
   },
-  "pre-commit": [
-    "precommit"
-  ],
+  "pre-commit": ["precommit"],
   "repository": {
     "type": "git",
     "url": "https+git://github.com/pburtchaell/react-notification"
@@ -52,6 +50,7 @@
     "chai": "^3.5.0",
     "chai-enzyme": "^0.6.0",
     "cheerio": "^0.22.0",
+    "cross-env": "^5.0.5",
     "enzyme": "^2.8.2",
     "eslint": "^3.10.2",
     "eslint-config-airbnb": "^13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1375,7 +1375,14 @@ create-react-class@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-cross-spawn@^5.0.1:
+cross-env@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.0.5.tgz#4383d364d9660873dd185b398af3bfef5efffef3"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
+cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -2729,6 +2736,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
 
 isarray@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
Similar to #115, the test script failed to run on Windows with the following:

```bash
> react-notification@6.8.0 test C:\clones\react-notification
> ./bin/test.sh

'.' is not recognized as an internal or external command,
operable program or batch file.
```

Using [`cross-env`](https://www.npmjs.com/package/cross-env) allows the script to run without a problem on Windows.