### PR TITLE
Support React 16.9 with UNSAFE_

### DIFF
--- a/src/notification.js
+++ b/src/notification.js
@@ -20,7 +20,7 @@ class Notification extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.dismissAfter === false) return;
 
     // See http://eslint.org/docs/rules/no-prototype-builtins

--- a/src/stackedNotification.js
+++ b/src/stackedNotification.js
@@ -23,7 +23,7 @@ class StackedNotification extends Component {
     this.dismiss(this.props.dismissAfter);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.dismissAfter !== this.props.dismissAfter) {
       this.dismiss(nextProps.dismissAfter);
     }


### PR DESCRIPTION
Add `UNSAFE_` to stop warning in React 16.9+ and prevent code from breaking in React 17